### PR TITLE
Fix Docker builds by removing ARM v7 platform support

### DIFF
--- a/.github/workflows/main-release.yml
+++ b/.github/workflows/main-release.yml
@@ -124,7 +124,7 @@ jobs:
         with:
           context: ./ServicesDashboard
           file: ./ServicesDashboard/Dockerfile
-          platforms: linux/amd64,linux/arm64,linux/arm/v7
+          platforms: linux/amd64,linux/arm64
           push: ${{ github.event_name != 'pull_request' }}
           tags: |
             ${{ secrets.DOCKER_USERNAME }}/servicesdashboard-backend:${{ steps.version.outputs.version_number }}
@@ -137,7 +137,7 @@ jobs:
         with:
           context: ./services-dashboard-frontend
           file: ./services-dashboard-frontend/Dockerfile.prod
-          platforms: linux/amd64,linux/arm64,linux/arm/v7
+          platforms: linux/amd64,linux/arm64
           push: ${{ github.event_name != 'pull_request' }}
           tags: |
             ${{ secrets.DOCKER_USERNAME }}/servicesdashboard-frontend:${{ steps.version.outputs.version_number }}
@@ -491,7 +491,7 @@ jobs:
             docker compose -f compose.prod.yaml up -d
             ```
 
-            Supported platforms: `linux/amd64`, `linux/arm64`, `linux/arm/v7`
+            Supported platforms: `linux/amd64`, `linux/arm64`
 
             > **⚠️ Note:** Raspberry Pi Zero / Pi 1 are NOT supported due to ARMv6 architecture limitations in .NET 9.0
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -71,7 +71,7 @@ jobs:
         with:
           context: ./ServicesDashboard
           file: ./ServicesDashboard/Dockerfile
-          platforms: linux/amd64,linux/arm64,linux/arm/v7
+          platforms: linux/amd64,linux/arm64
           push: true
           tags: |
             ${{ secrets.DOCKER_USERNAME }}/servicesdashboard-backend:${{ steps.version.outputs.version_number }}
@@ -84,7 +84,7 @@ jobs:
         with:
           context: ./services-dashboard-frontend
           file: ./services-dashboard-frontend/Dockerfile.prod
-          platforms: linux/amd64,linux/arm64,linux/arm/v7
+          platforms: linux/amd64,linux/arm64
           push: true
           tags: |
             ${{ secrets.DOCKER_USERNAME }}/servicesdashboard-frontend:${{ steps.version.outputs.version_number }}
@@ -385,7 +385,7 @@ jobs:
             docker compose -f compose.prod.yaml up -d
             ```
 
-            Supported platforms: `linux/amd64`, `linux/arm64`, `linux/arm/v7`
+            Supported platforms: `linux/amd64`, `linux/arm64`
 
             ### 📝 Installation
 


### PR DESCRIPTION
Removes linux/arm/v7 from multi-platform Docker builds due to .NET 9 QEMU
emulation issues in GitHub Actions causing build failures.

Issue:
- ARM v7 builds were failing with "qemu: uncaught target signal 6 (Aborted)"
- Exit code 134 during dotnet restore step
- Known .NET 9 incompatibility with QEMU ARM v7 emulation

Solution:
- Remove linux/arm/v7 from Docker build platforms
- Keep linux/amd64 and linux/arm64 support
- Update release notes to reflect supported platforms

Docker images now support:
- linux/amd64 (x64 systems)
- linux/arm64 (Raspberry Pi 4/5 64-bit, Apple Silicon)

ARM v7 users (Raspberry Pi 3/4 32-bit) can still use:
- Standalone binaries from GitHub releases
- Native platform builds from release workflow

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude <noreply@anthropic.com>
